### PR TITLE
Sync monorepo state at "Configure liveness probes to wait 10 seconds before starting to check  the health of the pod"

### DIFF
--- a/charts/userclouds-on-prem/CHANGELOG.md
+++ b/charts/userclouds-on-prem/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 - UNRELEASED
+
+- Configure liveness probes to wait 10 seconds before starting to check the health of the pod
+
 ## 0.5.1 - 22-10-2024
 
 - Fix DB Proxy NLB annotations indentation so additional annotations are rendered properly

--- a/charts/userclouds-on-prem/templates/authz.yaml
+++ b/charts/userclouds-on-prem/templates/authz.yaml
@@ -49,6 +49,7 @@ spec:
               containerPort: 5201
               protocol: TCP
           livenessProbe:
+            initialDelaySeconds: 10
             httpGet:
               path: /healthcheck
               port: authz

--- a/charts/userclouds-on-prem/templates/console.yaml
+++ b/charts/userclouds-on-prem/templates/console.yaml
@@ -53,6 +53,7 @@ spec:
               containerPort: 5301
               protocol: TCP
           livenessProbe:
+            initialDelaySeconds: 10
             httpGet:
               path: /healthcheck
               port: console

--- a/charts/userclouds-on-prem/templates/logserver.yaml
+++ b/charts/userclouds-on-prem/templates/logserver.yaml
@@ -51,6 +51,7 @@ spec:
               containerPort: 5501
               protocol: TCP
           livenessProbe:
+            initialDelaySeconds: 10
             httpGet:
               path: /healthcheck
               port: logserver

--- a/charts/userclouds-on-prem/templates/plex.yaml
+++ b/charts/userclouds-on-prem/templates/plex.yaml
@@ -50,6 +50,7 @@ spec:
               containerPort: 5001
               protocol: TCP
           livenessProbe:
+            initialDelaySeconds: 10
             httpGet:
               path: /healthcheck
               port: plex

--- a/charts/userclouds-on-prem/templates/userstore.yaml
+++ b/charts/userclouds-on-prem/templates/userstore.yaml
@@ -58,6 +58,7 @@ spec:
               containerPort: {{ $port }}
               protocol: TCP{{ end }}
           livenessProbe:
+            initialDelaySeconds: 10
             httpGet:
               path: /healthcheck
               port: userstore

--- a/charts/userclouds-on-prem/templates/worker.yaml
+++ b/charts/userclouds-on-prem/templates/worker.yaml
@@ -51,6 +51,7 @@ spec:
               containerPort: 5001
               protocol: TCP
           livenessProbe:
+            initialDelaySeconds: 10
             httpGet:
               path: /healthcheck
               port: worker


### PR DESCRIPTION
Syncing from userclouds/userclouds@84cb286f955d0e405a5395304b2479ed164340b4