### PR TITLE
Sync monorepo state at "upgrade redis for on prem, use AWS ECR instead of dockerhub"

### DIFF
--- a/charts/userclouds-on-prem/CHANGELOG.md
+++ b/charts/userclouds-on-prem/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.6.0 - UNRELEASED
 
 - Configure liveness probes to wait 10 seconds before starting to check the health of the pod
+- Upgrade to redis 7.4.1, pull it from AWS ECR, since it is faster when running in AWS and there is no risk of throttling (unlike DockerHub)
 
 ## 0.5.1 - 22-10-2024
 

--- a/charts/userclouds-on-prem/templates/redis.yaml
+++ b/charts/userclouds-on-prem/templates/redis.yaml
@@ -23,7 +23,7 @@ spec:
       {{- end }}
       containers:
         - name: redis
-          image: redis:6.0.8
+          image: public.ecr.aws/docker/library/redis:7.4.1
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}
           ports:


### PR DESCRIPTION
Syncing from userclouds/userclouds@c17a92f734c58ecae650e977970683200b49edec