### PR TITLE
Sync monorepo state at "Use a specific ubuntu version when running GHA CI"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ jobs:
   release:
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Syncing from userclouds/userclouds@e03089b75927e29355f2cad2a3cdab7484d58971