### PR TITLE
Sync monorepo state at "Upgrade on prem chart to use redis 7.4.2"

### DIFF
--- a/charts/userclouds-on-prem/CHANGELOG.md
+++ b/charts/userclouds-on-prem/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.8.0 - Unreleased
 
 - Don't retry failed jobs, this is to avoid the automatic provisioner to retry the same job multiple times in case of failure.
+- Upgrade to redis 7.4.2
 
 ## 0.7.0 - 07-02-2025
 

--- a/charts/userclouds-on-prem/templates/redis.yaml
+++ b/charts/userclouds-on-prem/templates/redis.yaml
@@ -23,7 +23,7 @@ spec:
       {{- end }}
       containers:
         - name: redis
-          image: public.ecr.aws/docker/library/redis:7.4.1
+          image: public.ecr.aws/docker/library/redis:7.4.2-alpine
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}
           ports:


### PR DESCRIPTION
Syncing from userclouds/userclouds@081a40968be1f8088a5a67a34d0d9dd988ab024e